### PR TITLE
cond: fixup path buffer size to fit the longest condition name

### DIFF
--- a/src/cond-w.c
+++ b/src/cond-w.c
@@ -206,7 +206,7 @@ static void cond_bump_reconf(void)
 
 static int cond_checkpath(const char *path)
 {
-	char buf[MAX_ARG_LEN], *dir;
+	char buf[MAX_COND_LEN + sizeof(_PATH_COND)], *dir;
 
 	strlcpy(buf, path, sizeof(buf));
 	dir = dirname(buf);

--- a/src/cond.c
+++ b/src/cond.c
@@ -47,7 +47,7 @@ const char *condstr(enum cond_state s)
 const char *cond_path(const char *name)
 {
 	static char path[256];
-	char tmp[MAX_ARG_LEN];
+	char tmp[MAX_COND_LEN + sizeof(_PATH_COND)];
 
 	snprintf(tmp, sizeof(tmp), _PATH_COND "%s", name);
 


### PR DESCRIPTION
cond_path() and cond_checkpath() built the /run/finit/cond/ path in a MAX_ARG_LEN buffer, so condition names longer than ~40 chars were truncated.

---

context: i started using `tasks` to mount disks in the `finix` initramfs (`.mount` units anyone? :laughing:) so i can mount in parallel, speed things up, properly order other tasks, etc... i found a bug where some longer paths created tasks which wouldn't create conditions under `/run/finit/cond/`... for example:

```
task wait-dev:dev-disk-by-label-FINIX_LIVE {
  command = "/nix/store/4a021xa6sr06qq58ixnqiq2h5zsg5sln-wait-dev_dev-disk-by-label-FINIX_LIVE"
  conditions = {  }
  runlevel = "S"
}
```

i did a bit of testing and with these patches seems fine now :+1: